### PR TITLE
Fix/duplicati punti di somministrazione

### DIFF
--- a/webservices/vaccini/puntiSomministrazione.py
+++ b/webservices/vaccini/puntiSomministrazione.py
@@ -5,7 +5,7 @@ import json
 
 # Converts the JSON output of a PowerBI query to a CSV file
 def extract(input_file, output_file):
-    input_json = read_json(input_file) 
+    input_json = read_json(input_file)
     data = input_json["results"][0]["result"]["data"]
     dm0 = data["dsr"]["DS"][0]["PH"][0]["DM0"]
     columns_types = dm0[0]["S"]
@@ -14,7 +14,7 @@ def extract(input_file, output_file):
 
     reconstruct_arrays(columns_types, dm0)
     expand_values(columns_types, dm0, value_dicts)
-    
+
     replace_newlines_with(dm0, "")
     write_csv(output_file, columns, dm0)
 
@@ -29,15 +29,15 @@ def write_csv(output_file, columns, dm0):
         for item in dm0:
             wrt.writerow(item["C"])
 
-def reconstruct_arrays(columns_types, dm0):    
-    # fixes array index by applying 
+def reconstruct_arrays(columns_types, dm0):
+    # fixes array index by applying
     # "R" bitset to copy previous values
-    # "Ø" bitset to null values
+    # "Ø" bitset to set null values
     lenght = len(columns_types)
     for item in dm0:
         currentItem = item["C"]
-        if "R" in item:
-            copyBitset = item["R"]
+        if "R" in item or "Ø" in item:
+            copyBitset = item.get("R", 0)
             deleteBitSet = item.get("Ø", 0)
             for i in range(lenght):
                 if is_bit_set_for_index(i, copyBitset):

--- a/webservices/vaccini/risorse/query_punti-di-somministrazione.json
+++ b/webservices/vaccini/risorse/query_punti-di-somministrazione.json
@@ -24,8 +24,7 @@
                                                 }
                                             },
                                             "Property": "REGIONI"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.REGIONI"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -35,8 +34,7 @@
                                                 }
                                             },
                                             "Property": "ID_AREA"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.ID_AREA"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -46,8 +44,7 @@
                                                 }
                                             },
                                             "Property": "AREA"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.AREA"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -57,8 +54,7 @@
                                                 }
                                             },
                                             "Property": "PROVINCIA"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.PROVINCIA"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -68,8 +64,7 @@
                                                 }
                                             },
                                             "Property": "COMUNE"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.COMUNE"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -79,8 +74,7 @@
                                                 }
                                             },
                                             "Property": "DEN_PRESIDIO_OSPEDALIERO"
-                                        },
-                                        "Name": "Count(cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.DEN_PRESIDIO_OSPEDALIERO)"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -90,8 +84,7 @@
                                                 }
                                             },
                                             "Property": "INDIRIZZO"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.INDIRIZZO"
+                                        }
                                     },
                                     {
                                         "Column": {
@@ -101,8 +94,7 @@
                                                 }
                                             },
                                             "Property": "CAP"
-                                        },
-                                        "Name": "cfg VACCINI_PUNTI_SOMMINISTRAZIONE_DOSI_REGIONI.CAP"
+                                        }
                                     }
                                 ],
                                 "GroupBy": [
@@ -181,9 +173,6 @@
                                                 5,
                                                 6,
                                                 7
-                                            ],
-                                            "GroupBy": [
-                                                0
                                             ]
                                         }
                                     ]


### PR DESCRIPTION
Questa PR evita di scaricare duplicati con la query dei punti di somministrazione (293 invece di 586).